### PR TITLE
single level wildcard support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@
 organization := "com.sandinh"
 name := "paho-akka"
 
-version := "1.5.3-inspired"
+version := "1.6.0-inspired"
 
 scalaVersion := "2.12.5"
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@
 organization := "com.sandinh"
 name := "paho-akka"
 
-version := "1.6.0-inspired"
+version := "1.6.2-inspired"
 
 scalaVersion := "2.12.5"
 

--- a/src/main/scala/com/sandinh/paho/akka/MqttPubSub.scala
+++ b/src/main/scala/com/sandinh/paho/akka/MqttPubSub.scala
@@ -156,10 +156,9 @@ class MqttPubSub(cfg: PSConfig) extends FSM[PSState, Unit] {
     case Event(msg: Message, _) =>
       context.child(urlEnc(msg.topic)) foreach (_ ! msg)
       subscribed.foreach{subscribedRef =>
-        if (matchMultiLevelWildcard(subscribedRef.topic,msg.topic) || matchSingleLevelWildcard(subscribedRef.topic,msg.topic))
+        if ((matchMultiLevelWildcard(subscribedRef.topic,msg.topic) || matchSingleLevelWildcard(subscribedRef.topic,msg.topic)) && (subscribedRef.topic != msg.topic))
           subscribedRef.ref ! msg
       }
-      context.child(urlEnc(msg.topic)) foreach (_ ! msg)
       stay()
 
     case Event(UnderlyingSubsAck(topic, fail), _) =>


### PR DESCRIPTION
Added single level wildcard support. However only for one single level wildcard and not in combination with other single level wildcards or a multi level wildcard as specified in the [specification](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/csprd02/mqtt-v3.1.1-csprd02.html#_Toc385349843). If we have this requirement in the future we need to extend the matching.